### PR TITLE
Parse HTTP `connection` header as case-insensitive.

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -80,13 +80,13 @@ module Protocol
 				end
 				
 				if version == HTTP10
-					if connection = headers[CONNECTION]
+					if connection = headers[CONNECTION]&.downcase
 						return connection.include?(KEEP_ALIVE)
 					else
 						return false
 					end
 				else
-					if connection = headers[CONNECTION]
+					if connection = headers[CONNECTION]&.downcase
 						return !connection.include?(CLOSE)
 					else
 						return true

--- a/spec/protocol/http1/connection_spec.rb
+++ b/spec/protocol/http1/connection_spec.rb
@@ -99,10 +99,35 @@ RSpec.describe Protocol::HTTP1::Connection do
 				server.read_request
 			end.to raise_error(Protocol::HTTP1::InvalidRequest)
 		end
-		
-		it "should be persistent by default" do
-			expect(client).to be_persistent('HTTP/1.1', "GET", {})
-			expect(server).to be_persistent('HTTP/1.1', "GET", {})
+	end
+
+	describe '#persistent?' do
+		describe "HTTP 1.0" do
+			it "should not be persistent by default" do
+				expect(server).not_to be_persistent("HTTP/1.0", "GET", {})
+			end
+
+			it "should be persistent if connection: keep-alive is set" do
+				expect(server).to be_persistent("HTTP/1.0", "GET", { "connection" => "keep-alive" })
+			end
+
+			it "should allow case-insensitive 'connection' value" do
+				expect(server).to be_persistent("HTTP/1.0", "GET", { "connection" => "Keep-Alive" })
+			end
+		end
+
+		describe "HTTP 1.1" do
+			it "should be persistent by default" do
+				expect(server).to be_persistent("HTTP/1.1", "GET", {})
+			end
+
+			it "should not be persistent if connection: close is set" do
+				expect(server).not_to be_persistent("HTTP/1.1", "GET", { "connection" => "close" })
+			end
+
+			it "should allow case-insensitive 'connection' value" do
+				expect(server).not_to be_persistent("HTTP/1.1", "GET", { "connection" => "Close" })
+			end
 		end
 	end
 	


### PR DESCRIPTION
Although HTTP header values are case-sensitive in general,
RFC 7230 https://tools.ietf.org/html/rfc7230#section-6.1 says:
"Connection options are case-insensitive."

See also:
- https://stackoverflow.com/a/25660341/468618
- The "Connection" example in the MDN Keep-Alive docs:
  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive

An alternative is to move this logic into to `protocol-http`
gem, but it would have to be specific to the `connection`
header because many other headers are case-sensitive.
If you want it there, the logic would go in the `[]=` method
to avoid having to check in multiple places (`fields`, `each`,
`extract`, `to_h`, `inspect`, `==`).
