### PR TITLE
Make host header configurable

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -136,8 +136,14 @@ module Protocol
 			end
 			
 			def write_request(authority, method, path, version, headers)
+				host = authority
+				if headers.include?("host")
+					host = headers["host"]
+					headers.delete "host"
+				end
+				
 				@stream.write("#{method} #{path} #{version}\r\n")
-				@stream.write("host: #{authority}\r\n")
+				@stream.write("host: #{host}\r\n")
 				
 				write_headers(headers)
 			end


### PR DESCRIPTION
I know it's an edge case but sometimes I need to set `host` header manually for a debugging purpose.

The current implementation forces to use the default `host` header (= `authority`). So it is not possible to set the `host` header manually.

This PR will make possible to configure `host` header manually if it is given via `headers`.