### PR TITLE
Fix typo in Connection

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -368,7 +368,7 @@ module Protocol
 				if body.nil?
 					write_connection_header(version)
 					write_empty_body(body)
-				elsif length = body.length and (VERSION != HTTP11 && trailers.nil?)
+				elsif length = body.length and (version != HTTP11 && trailers.nil?)
 					write_connection_header(version)
 					write_fixed_length_body(body, length, head)
 				elsif body.empty?

--- a/spec/protocol/http1/connection_spec.rb
+++ b/spec/protocol/http1/connection_spec.rb
@@ -265,6 +265,14 @@ RSpec.describe Protocol::HTTP1::Connection do
 			expect(server).to receive(:write_chunked_body)
 			server.write_body("HTTP/1.1", body)
 		end
+
+		it "always writes chunked body for HTTP/1.1" do
+			expect(body).to receive(:empty?).and_return(false)
+			expect(body).to receive(:length).and_return(1024)
+			
+			expect(server).to receive(:write_chunked_body)
+			server.write_body("HTTP/1.1", body)
+		end
 		
 		it "can write closed body" do
 			expect(server.persistent).to be true


### PR DESCRIPTION
Fix a dangerous typo in `Connection` class. `VERSION` evaluates to gem version not HTTP protocol version.

With this correction HTTP11 protocol version is unable to write fixed length bodies. Instead, it defaults to writing chunked bodies (this is covered with a spec).

I don't know if this behavior is desired. If no then maybe we should remove this condition `version != HTTP11`.

## Types of Changes

- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

- [x] I added new tests for my changes.
- [x] I ran all the tests locally.
