### PR TITLE
Allow HTTP/1.1 connections to write fixed length bodies.

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -368,7 +368,7 @@ module Protocol
 				if body.nil?
 					write_connection_header(version)
 					write_empty_body(body)
-				elsif length = body.length and (version != HTTP11 && trailers.nil?)
+				elsif length = body.length and trailers.nil?
 					write_connection_header(version)
 					write_fixed_length_body(body, length, head)
 				elsif body.empty?

--- a/spec/protocol/http1/connection_spec.rb
+++ b/spec/protocol/http1/connection_spec.rb
@@ -265,12 +265,11 @@ RSpec.describe Protocol::HTTP1::Connection do
 			expect(server).to receive(:write_chunked_body)
 			server.write_body("HTTP/1.1", body)
 		end
-
-		it "always writes chunked body for HTTP/1.1" do
-			expect(body).to receive(:empty?).and_return(false)
+		
+		it "can write fixed length body for HTTP/1.1" do
 			expect(body).to receive(:length).and_return(1024)
 			
-			expect(server).to receive(:write_chunked_body)
+			expect(server).to receive(:write_fixed_length_body)
 			server.write_body("HTTP/1.1", body)
 		end
 		


### PR DESCRIPTION
In https://github.com/socketry/protocol-http1/pull/9 we discussed whether HTTP/1.1 should be allowed to send fixed length body. This PR implements the proposed change. We may need to check if there are unexpected changes downstream (e.g. buffering issues).

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix.
- [x] New feature.
- [x] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [x] I added new tests for my changes.
- [x] I ran all the tests locally.

cc @bruno- 
