### PR TITLE
Fix/nil read line

### DIFF
--- a/lib/protocol/http1/body/chunked.rb
+++ b/lib/protocol/http1/body/chunked.rb
@@ -56,8 +56,11 @@ module Protocol
 				# Follows the procedure outlined in https://tools.ietf.org/html/rfc7230#section-4.1.3
 				def read
 					return nil if @finished
+
+					chunk_size_line = read_line
+					return nil unless chunk_size_line
 					
-					length = read_line.to_i(16)
+					length = chunk_size_line.to_i(16)
 					
 					if length == 0
 						@finished = true
@@ -69,6 +72,7 @@ module Protocol
 					
 					# Read trailing CRLF:
 					chunk = @stream.read(length + 2)
+					return nil unless chunk
 					
 					# ...and chomp it off:
 					chunk.chomp!(CRLF)

--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -197,8 +197,6 @@ module Protocol
 				@count += 1
 				
 				return headers.delete(HOST), method, path, version, headers, body
-			rescue IOError
-				return nil
 			end
 			
 			def read_response(method)

--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -171,6 +171,8 @@ module Protocol
 			
 			def read_line?
 				@stream.gets(CRLF, chomp: true)
+			rescue IOError, Errno::ECONNRESET
+				return nil
 			end
 			
 			def read_line

--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -195,6 +195,8 @@ module Protocol
 				@count += 1
 				
 				return headers.delete(HOST), method, path, version, headers, body
+			rescue IOError
+				return nil
 			end
 			
 			def read_response(method)


### PR DESCRIPTION
Hi, this PR addresses some rare [issues](https://github.com/socketry/protocol-http1/issues/12) when client dies suddenly causing IOError in IO.gets/Async::IO::Stream.read_until methods. [This PR](https://github.com/socketry/async-http/pull/70) for [async-http](https://github.com/socketry/async-http) covers the same error