### PR TITLE
Strict validation of content length and chunk length.

### DIFF
--- a/lib/protocol/http1/body/chunked.rb
+++ b/lib/protocol/http1/body/chunked.rb
@@ -35,12 +35,20 @@ module Protocol
 					super
 				end
 				
+				VALID_CHUNK_LENGTH = /\A[0-9a-fA-F]+\z/
+				
 				# Follows the procedure outlined in https://tools.ietf.org/html/rfc7230#section-4.1.3
 				def read
 					return nil if @finished
 					
+					length, extensions = read_line.split(";", 2)
+					
+					unless length =~ VALID_CHUNK_LENGTH
+						raise BadRequest, "Invalid chunk length: #{length.dump}"
+					end
+					
 					# It is possible this line contains chunk extension, so we use `to_i` to only consider the initial integral part:
-					length = read_line.to_i(16)
+					length = Integer(length, 16)
 					
 					if length == 0
 						@finished = true

--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -398,10 +398,12 @@ module Protocol
 			HEAD = "HEAD"
 			CONNECT = "CONNECT"
 			
+			VALID_CONTENT_LENGTH = /\A\d+\z/
+			
 			def extract_content_length(headers)
 				if content_length = headers.delete(CONTENT_LENGTH)
-					if length = Integer(content_length, exception: false) and length >= 0
-						yield length
+					if content_length =~ VALID_CONTENT_LENGTH
+						yield Integer(content_length, 10)
 					else
 						raise BadRequest, "Invalid content length: #{content_length}"
 					end

--- a/test/protocol/http1/connection.rb
+++ b/test/protocol/http1/connection.rb
@@ -208,7 +208,7 @@ describe Protocol::HTTP1::Connection do
 		
 		with "HEAD" do
 			it "can read length of head response" do
-				body = client.read_response_body("HEAD", 200, {'content-length' => 3773})
+				body = client.read_response_body("HEAD", 200, {'content-length' => '3773'})
 				
 				expect(body).to be_a ::Protocol::HTTP::Body::Head
 				expect(body.length).to be == 3773
@@ -216,7 +216,7 @@ describe Protocol::HTTP1::Connection do
 			end
 			
 			it "ignores zero length body" do
-				body = client.read_response_body("HEAD", 200, {'content-length' => 0})
+				body = client.read_response_body("HEAD", 200, {'content-length' => '0'})
 				
 				expect(body).to be_nil
 			end

--- a/test/protocol/http1/connection/bad.rb
+++ b/test/protocol/http1/connection/bad.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2019-2023, by Samuel Williams.
+
+require 'protocol/http1/connection'
+require 'connection_context'
+
+describe Protocol::HTTP1::Connection do
+	include_context ConnectionContext
+	
+	def before
+		super
+		
+		client.stream.write(input)
+		client.stream.close
+	end
+	
+	with "invalid hexadecimal content-length" do
+		def input
+			<<~HTTP.gsub("\n", "\r\n")
+			POST / HTTP/1.1
+			Host: a.com
+			Content-Length: 0x10
+			Connection: close
+			
+			0123456789abcdef
+			HTTP
+		end
+		
+		it "should fail to parse the request body" do
+			expect do
+				server.read_request
+			end.to raise_exception(Protocol::HTTP1::BadRequest)
+		end
+	end
+	
+	with "invalid +integer content-length" do
+		def input
+			<<~HTTP.gsub("\n", "\r\n")
+			POST / HTTP/1.1
+			Host: a.com
+			Content-Length: +16
+			Connection: close
+			
+			0123456789abcdef
+			HTTP
+		end
+		
+		it "should fail to parse the request body" do
+			expect do
+				server.read_request
+			end.to raise_exception(Protocol::HTTP1::BadRequest)
+		end
+	end
+	
+	with "invalid -integer content-length" do
+		def input
+			<<~HTTP.gsub("\n", "\r\n")
+			POST / HTTP/1.1
+			Host: a.com
+			Content-Length: -16
+			Connection: close
+			
+			0123456789abcdef
+			HTTP
+		end
+		
+		it "should fail to parse the request body" do
+			expect do
+				server.read_request
+			end.to raise_exception(Protocol::HTTP1::BadRequest)
+		end
+	end
+	
+	with "invalid hexidecimal chunk size" do
+		def input
+			<<~HTTP.gsub("\n", "\r\n")
+			POST / HTTP/1.1
+			Host: a.com
+			Transfer-Encoding: chunked
+			Connection: close
+			
+			0x10
+			0123456789abcdef
+			0
+			HTTP
+		end
+		
+		it "should fail to parse the request body" do
+			authority, method, target, version, headers, body = server.read_request
+			
+			expect(body).to be_a(Protocol::HTTP1::Body::Chunked)
+			
+			expect do
+				body.read
+			end.to raise_exception(Protocol::HTTP1::BadRequest)
+		end
+	end
+	
+	with "invalid +integer chunk size" do
+		def input
+			<<~HTTP.gsub("\n", "\r\n")
+			POST / HTTP/1.1
+			Host: a.com
+			Transfer-Encoding: chunked
+			Connection: close
+			
+			+10
+			0123456789abcdef
+			0
+			HTTP
+		end
+		
+		it "should fail to parse the request body" do
+			authority, method, target, version, headers, body = server.read_request
+			
+			expect(body).to be_a(Protocol::HTTP1::Body::Chunked)
+			
+			expect do
+				body.read
+			end.to raise_exception(Protocol::HTTP1::BadRequest)
+		end
+	end
+end


### PR DESCRIPTION
Security researchers @mukeran and @chenjj have reported issues with parsing content length and chunk lengths:

[RFC 9112 Section 7.1](https://www.rfc-editor.org/rfc/rfc9112#name-chunked-transfer-coding) defined the format of chunk size, chunk data and chunk extension (detailed ABNF is in Appendix secion).

In a word:

- The value of Content-Length header should be a string of 0-9 digits.
- The chunk size should be a string of hex digits and should split from chunk data using CRLF.
- The chunk extension shouldn't contain any invisible character.

However, we found that Falcon has following behaviors while disobey the corresponding RFCs.

- Falcon accepts Content-Length header values that have "+" prefix.
- Falcon accepts Content-Length header values that written in hexadecimal with "0x" prefix.
- Falcon accepts "0x" and "+" prefixed chunk size.
- Falcon accepts LF in chunk extension.

This behavior can lead to desync when forwarding through multiple HTTP parsers, potentially results in HTTP request smuggling and firewall bypassing.

When sending the following requests to the server, falcon successfully parsed our requests and our application successfully read request body.

## Impact

The above is a valid assessment of the behaviour of the HTTP/1 parser. However, as this gem does not expose the raw body or forward it in any way, I don't believe it can cause issues in the real world. However, I accept that stricter parsing of the length fields is a good idea.

Regarding chunk extensions, these are ignored and not exposed to the user. Therefore, I don't believe it would be valuable to validate these. Feel free to correct me here.

## Actions

- Adopt stricter parsing of the content length field according to the RFC.
- Adopt stricter parsing of the chunk length according to the RFC.
- Explicitly ignore any chunk extension fields.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Security

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
