### PR TITLE
Add request & response hooks

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -115,6 +115,8 @@ module Protocol
 			end
 			
 			def write_request(authority, method, path, version, headers)
+				sending_request if respond_to?(:sending_request)
+				
 				@stream.write("#{method} #{path} #{version}\r\n")
 				@stream.write("host: #{authority}\r\n")
 				
@@ -157,7 +159,11 @@ module Protocol
 			end
 			
 			def read_request
+				waiting_for_request if respond_to?(:waiting_for_request)
+
 				return unless line = read_line?
+				
+				receiving_request if respond_to?(:receiving_request)
 				
 				if match = line.match(REQUEST_LINE)
 					_, method, path, version = *match
@@ -177,11 +183,15 @@ module Protocol
 			end
 			
 			def read_response(method)
+				waiting_for_response if respond_to?(:waiting_for_response)
+				
 				version, status, reason = read_line.split(/\s+/, 3)
 				
 				status = Integer(status)
 				
 				headers = read_headers
+				
+				received_response if respond_to?(:received_response)
 				
 				@persistent = persistent?(version, method, headers)
 				


### PR DESCRIPTION
Exploratory PR to add request & response hooks for the primary purpose of configuring multiple timeouts. Potentially useful for metrics or other things too.

Part 1/2: this PR
Part 2/2: socketry/async-http#130

See socketry/async-http#127 for discussion.

## Types of Changes

- New feature.

## Contribution

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
