### PR TITLE
Fix ruby warning

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Thomas Morgan <tm@iprog.com>

--- a/lib/protocol/http1/body/chunked.rb
+++ b/lib/protocol/http1/body/chunked.rb
@@ -41,7 +41,7 @@ module Protocol
 				def read
 					return nil if @finished
 					
-					length, extensions = read_line.split(";", 2)
+					length, _extensions = read_line.split(";", 2)
 					
 					unless length =~ VALID_CHUNK_LENGTH
 						raise BadRequest, "Invalid chunk length: #{length.dump}"


### PR DESCRIPTION
This PR fixes this warning from ruby 3.2.2:
```
.../protocol-http1-0.15.1/lib/protocol/http1/body/chunked.rb:44: warning: assigned but unused variable - extensions
```

## Types of Changes

- Maintenance.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
