### PR TITLE
Breakout reading of request and response prefaces

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -173,7 +173,7 @@ module Protocol
 				read_line? or raise EOFError
 			end
 			
-			def read_request_preface
+			def read_request_line
 				return unless line = read_line?
 				
 				if match = line.match(REQUEST_LINE)
@@ -186,7 +186,7 @@ module Protocol
 			end
 			
 			def read_request
-				method, path, version = read_request_preface
+				method, path, version = read_request_line
 				return unless method
 				
 				headers = read_headers
@@ -200,7 +200,7 @@ module Protocol
 				return headers.delete(HOST), method, path, version, headers, body
 			end
 			
-			def read_response_preface
+			def read_status_line
 				version, status, reason = read_line.split(/\s+/, 3)
 				
 				status = Integer(status)
@@ -209,7 +209,7 @@ module Protocol
 			end
 			
 			def read_response(method)
-				version, status, reason = read_response_preface
+				version, status, reason = read_status_line
 				
 				headers = read_headers
 				

--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -173,7 +173,7 @@ module Protocol
 				read_line? or raise EOFError
 			end
 			
-			def read_request
+			def read_request_preface
 				return unless line = read_line?
 				
 				if match = line.match(REQUEST_LINE)
@@ -181,6 +181,13 @@ module Protocol
 				else
 					raise InvalidRequest, line.inspect
 				end
+				
+				return method, path, version
+			end
+			
+			def read_request
+				method, path, version = read_request_preface
+				return unless method
 				
 				headers = read_headers
 				
@@ -193,10 +200,16 @@ module Protocol
 				return headers.delete(HOST), method, path, version, headers, body
 			end
 			
-			def read_response(method)
+			def read_response_preface
 				version, status, reason = read_line.split(/\s+/, 3)
 				
 				status = Integer(status)
+				
+				return version, status, reason
+			end
+			
+			def read_response(method)
+				version, status, reason = read_response_preface
 				
 				headers = read_headers
 				


### PR DESCRIPTION
This PR splits off reading of the first line of both requests and responses into separate methods. It makes no functional changes.

The intent is to make it easier to inject added functionality after reading the first line (ie: preface) or before reading the headers, most likely via a monkeypatch.

Immediate use case: changing the IO stream timeout before and after reading the preface line.

Related to socketry/async-http#127.


## Types of Changes

- New feature.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
