### PR TITLE
Avoid unused variable warning in chunked.rb

### DIFF
--- a/lib/protocol/http1/body/chunked.rb
+++ b/lib/protocol/http1/body/chunked.rb
@@ -41,7 +41,7 @@ module Protocol
 				def read
 					return nil if @finished
 					
-					length, extensions = read_line.split(";", 2)
+					length, _extensions = read_line.split(";", 2)
 					
 					unless length =~ VALID_CHUNK_LENGTH
 						raise BadRequest, "Invalid chunk length: #{length.dump}"


### PR DESCRIPTION


This would have emitted warning: assigned but unused variable - extensions.

## Types of Changes

- Maintenance.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
