### PR TITLE
Ensure 1xx and Remainder responses mark connection as not persistent

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -423,6 +423,7 @@ module Protocol
 			end
 			
 			def read_remainder_body
+				@persistent = false
 				Body::Remainder.new(@stream)
 			end
 			
@@ -469,7 +470,14 @@ module Protocol
 					return nil
 				end
 				
-				if (status >= 100 and status < 200) or status == 204 or status == 304
+				if status >= 100 and status < 200
+					# At the moment this is returned, the Remainder represents any
+					# future response on the stream. The Remainder may be used directly
+					# or discarded, or read_response may be called again.
+					return read_remainder_body
+				end
+				
+				if status == 204 or status == 304
 					return nil
 				end
 				

--- a/test/protocol/http1/connection.rb
+++ b/test/protocol/http1/connection.rb
@@ -204,7 +204,9 @@ describe Protocol::HTTP1::Connection do
 	with '#read_response_body' do
 		with "GET" do
 			it "should ignore body for informational responses" do
-				expect(client.read_response_body("GET", 100, {'content-length' => '10'})).to be_nil
+				body = client.read_response_body("GET", 100, {'content-length' => '10'})
+				expect(body).to be_a(::Protocol::HTTP1::Body::Remainder)
+				expect(client.persistent).to be == false
 			end
 			
 			it "should ignore body for no content responses" do
@@ -214,6 +216,7 @@ describe Protocol::HTTP1::Connection do
 			it "should handle non-chunked transfer-encoding" do
 				body = client.read_response_body("GET", 200, {'transfer-encoding' => ['identity']})
 				expect(body).to be_a(::Protocol::HTTP1::Body::Remainder)
+				expect(client.persistent).to be == false
 			end
 			
 			it "should be an error if both transfer-encoding and content-length is set" do

--- a/test/protocol/http1/hijack.rb
+++ b/test/protocol/http1/hijack.rb
@@ -44,7 +44,7 @@ describe Protocol::HTTP1::Connection do
 			expect(version).to be == response_version
 			expect(status).to be == 101
 			expect(headers).to be == response_headers
-			expect(body).to be_nil # due to 101 status
+			expect(body).to be_a(::Protocol::HTTP1::Body::Remainder) # due to 101 status
 			
 			client_stream = client.hijack!
 			


### PR DESCRIPTION
This PR ensures that responses with either 1xx statuses or `Remainder` bodies both set `@persistent = false`.

1xx statuses indicate that the current response is not complete. Similarly, `Remainder` bodies indicate an indeterminate body and thus an inability to know when it is complete. In both cases, this makes it important to mark the client connection as not persistent.

This is required so that `Async::Pool::Controller` will not accidentally attempt to reuse the connection. When determining whether a connection is eligible for reuse, Pool calls `connection.reusable?`, which in turn references `@persistent`.

The choice to modify `@persistent` inside `read_remainder_body` was chosen as it parallels similar behavior in various `write_*` methods. I also considered adding logic to `#persistent?` to check `status`. While that would work for 1xx statuses, there are also other instances of returning a `Remainder` body (via `#read_remainder_body`), some of which cannot reasonably be checked inside `#persistent?`.

This PR changes 1xx responses to return a `Remainder` instead of `nil`. Returning `nil` previously seemed like a bug in its own right, as there is definitely more on the stream and returning `nil` is misleading. If the `Remainder` body is unused, as it would be when a websockets connection hijacks the connection, there is no harm. However, if websockets is unused or if it fails to hijack the connection (perhaps because the WS headers are incorrect), this ensures any following client code sees a body and not `nil`.

I tested this against `async-websockets` and tests still pass with body as a `Remainder`.

Related, any response with `body=nil` is ineligible to be wrapped, whether by `Statistics`, `Client`'s deferred checkin for `Pool::Controller`, or otherwise. In the case of Pool, this can cause a premature checkin, which can potentially lead to reuse of a connection before the current client is finished with it. Failing to wrap responses because of a `nil` body is a separate issue, but I wanted to solve this in a manner congruent with improving that overall situation by assigning an actual Body.

Lastly, since `async-http` recently added handling of 1xx statuses (yay!), two additional thoughts:

First, when `Request.read` loops on `read_response` due to 1xx statuses, `read_response` will recalculate `@persistent=` on each iteration. This works great and will ensure that as long as the connection eventually ends in a final status (other than 101), the connection ends as persistent/reusable. Even though considered final by `protocol-http`, 101's will be marked as not persistent, again proper since the connection cannot be reused for http once the protocol has been upgraded (to websockets or otherwise).

Second, the changes here make `protocol-http1` and `persistent` do the right thing independent of `async-http`. That is, 1xx responses aren't relying on the looping behavior of `async-http` to be safe.

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
