### PR TITLE
Allow persistent=false to be set externally

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -59,8 +59,8 @@ module Protocol
 			attr :stream
 			
 			# Whether the connection is persistent.
-			# This determines what Connection headers are sent in the response and whether
-			# async-http is willing to reuse the connection/stream after the response.
+			# This determines what connection headers are sent in the response and whether
+			# the connection can be reused after the response is sent.
 			# This setting is automatically managed according to the nature of the request
 			# and response.
 			# Changing to false is safe.

--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -59,7 +59,14 @@ module Protocol
 			attr :stream
 			
 			# Whether the connection is persistent.
-			attr :persistent
+			# This determines what Connection headers are sent in the response and whether
+			# async-http is willing to reuse the connection/stream after the response.
+			# This setting is automatically managed according to the nature of the request
+			# and response.
+			# Changing to false is safe.
+			# Changing to true from outside this class should generally be avoided and,
+			# depending on the response semantics, may be reset to false anyway.
+			attr_accessor :persistent
 			
 			# The number of requests processed.
 			attr :count


### PR DESCRIPTION
This PR allows `connection.persistent = false` to be called externally.

Use cases:

1. Server connections - As part of a more graceful shutdown, I want in-flight connections to be allowed to finish the current request/response, but then terminate and not be reused. In addition to closing the connection, flagging connections in this way allows them to return a `Connection: closed` header so the client is properly notified that this connection isn't to be reused for further requests.

2. Client connections - When certain conditions are met, I want to flag client connections as not eligible to be returned to the Pool for reuse. This could be because the connection configuration has changed, a maximum request count has been reached, etc.

##### Alternatives

I'm not sure setting `connection.persistent = true` is ever warranted. As such, I considered adding a `#not_persistent!` method instead that only sets to `false`. I chose to go with the simpler solution of an accessor, but going with something more opinionated is an option if preferred.

## Types of Changes

- New feature.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
