### PR TITLE
`eof?` can and does block, so let's avoid it.

### DIFF
--- a/lib/protocol/http1/body/remainder.rb
+++ b/lib/protocol/http1/body/remainder.rb
@@ -14,15 +14,17 @@ module Protocol
 				# block_size may be removed in the future. It is better managed by stream.
 				def initialize(stream)
 					@stream = stream
+					@empty = false
 				end
 				
 				def empty?
-					@stream.eof? or @stream.closed?
+					@empty or @stream.closed?
 				end
 				
 				def close(error = nil)
 					# We can't really do anything in this case except close the connection.
 					@stream.close
+					@empty = true
 					
 					super
 				end
@@ -31,6 +33,8 @@ module Protocol
 				def read
 					@stream.readpartial(BLOCK_SIZE)
 				rescue EOFError, IOError
+					@empty = true
+					
 					# I noticed that in some cases you will get EOFError, and in other cases IOError!?
 					return nil
 				end
@@ -45,6 +49,8 @@ module Protocol
 				
 				def join
 					@stream.read
+				ensure
+					@empty = true
 				end
 				
 				def inspect

--- a/test/protocol/http1/body/remainder.rb
+++ b/test/protocol/http1/body/remainder.rb
@@ -37,12 +37,11 @@ describe Protocol::HTTP1::Body::Remainder do
 	
 	with "#read" do
 		it "retrieves chunks of content" do
+			expect(body).not.to be(:empty?)
+			
 			expect(body.read).to be == "Hello World"
 			expect(body.read).to be == nil
-		end
-		
-		it "updates number of bytes retrieved" do
-			body.read
+			
 			expect(body).to be(:empty?)
 		end
 	end
@@ -57,12 +56,11 @@ describe Protocol::HTTP1::Body::Remainder do
 	
 	with "#join" do
 		it "returns all content" do
+			expect(body).not.to be(:empty?)
+			
 			expect(body.join).to be == "Hello World"
 			expect(body.join).to be == ""
-		end
-		
-		it "updates number of bytes retrieved" do
-			body.read
+			
 			expect(body).to be(:empty?)
 		end
 	end


### PR DESCRIPTION
It turns out that for sockets, `eof?` can block. In `empty?` we optimistically care about whether there is data or not, and don't want to block.

See https://bugs.ruby-lang.org/issues/20215 for more context.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
