### PR TITLE
Adding #hijacked? method to connection

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -53,7 +53,6 @@ module Protocol
 				@stream = stream
 				
 				@persistent = persistent
-				@hijacked = false
 				
 				@count = 0
 			end
@@ -110,14 +109,13 @@ module Protocol
 			# IO has been handed over and is not usable anymore.
 			# @return [Boolean] hijack status
 			def hijacked?
-				@hijacked
+				@stream.nil?
 			end
 			
 			# Effectively close the connection and return the underlying IO.
 			# @return [IO] the underlying non-blocking IO.
 			def hijack!
 				@persistent = false
-				@hijacked = true
 				stream = @stream
 				
 				@stream.flush

--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -53,6 +53,7 @@ module Protocol
 				@stream = stream
 				
 				@persistent = persistent
+				@hijacked = false
 				
 				@count = 0
 			end
@@ -104,11 +105,19 @@ module Protocol
 			def write_upgrade_header(upgrade)
 				@stream.write("connection: upgrade\r\nupgrade: #{upgrade}\r\n")
 			end
+
+			# Indicates whether the connection has been hijacked meaning its
+			# IO has been handed over and is not usable anymore.
+			# @return [Boolean] hijack status
+			def hijacked?
+				@hijacked
+			end
 			
 			# Effectively close the connection and return the underlying IO.
 			# @return [IO] the underlying non-blocking IO.
 			def hijack!
 				@persistent = false
+				@hijacked = true
 				stream = @stream
 				
 				@stream.flush

--- a/test/protocol/http1/hijack.rb
+++ b/test/protocol/http1/hijack.rb
@@ -19,11 +19,17 @@ describe Protocol::HTTP1::Connection do
 			server_wrapper = server.hijack!
 			expect(server.persistent).to be == false
 		end
+
+		it "should repord itself as #hijacked? after the hijack" do
+			expect(server.hijacked?).to be == false
+			server.hijack!
+			expect(server.hijacked?).to be == true
+		end
 		
 		it "should use non-chunked output" do
 			expect(body).to receive(:ready?).and_return(false)
 			expect(body).to receive(:empty?).and_return(false)
-			expect(body).to receive(:length).and_return(nil)
+			expect(body).to receive(:length).twice.and_return(nil)
 			expect(body).to receive(:each).and_return(nil)
 			
 			expect(server).to receive(:write_body_and_close)


### PR DESCRIPTION
A plain simple `#hijacked?` getter indicating hijack status of the connection. 
This change's ultimate goal is become a part of  https://github.com/socketry/async-http/pull/151.

## Types of Changes

- New feature.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
