### PR TITLE
Invoke `flush` before `close_write` in `write_body_and_close`.

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -379,6 +379,7 @@ module Protocol
 					end
 				end
 				
+				@stream.flush
 				@stream.close_write
 			end
 			


### PR DESCRIPTION
It does not appear guaranteed that `close_write` will flush the underlying IO buffers, so let's ensure it's flushed.

I encountered this problem when implementing `async-http` using native IO.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
