### PR TITLE
Improve request upgrade body handling.

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -503,6 +503,11 @@ module Protocol
 					return read_tunnel_body
 				end
 				
+				# A successful upgrade response implies that the connection will become a tunnel immediately after the empty line that concludes the header fields.
+				if headers[UPGRADE]
+					return read_tunnel_body
+				end
+				
 				# 6.  If this is a request message and none of the above are true, then
 				# the message body length is zero (no message body is present).
 				return read_body(headers)

--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -435,6 +435,12 @@ module Protocol
 				read_remainder_body
 			end
 			
+			def read_upgrade_body
+				# When you have an incoming upgrade request body, we must be extremely careful not to start reading it until the upgrade has been confirmed, otherwise if the upgrade was rejected and we started forwarding the incoming request body, it would desynchronize the connection (potential security issue).
+				# We mitigate this issue by setting @persistent to false, which will prevent the connection from being reused, even if the upgrade fails (potential performance issue).
+				read_remainder_body
+			end
+			
 			HEAD = "HEAD"
 			CONNECT = "CONNECT"
 			
@@ -470,14 +476,11 @@ module Protocol
 					return nil
 				end
 				
-				if status >= 100 and status < 200
-					# At the moment this is returned, the Remainder represents any
-					# future response on the stream. The Remainder may be used directly
-					# or discarded, or read_response may be called again.
-					return read_remainder_body
+				if status == 101
+					return read_upgrade_body
 				end
 				
-				if status == 204 or status == 304
+				if (status >= 100 and status < 200) or status == 204 or status == 304
 					return nil
 				end
 				
@@ -505,7 +508,7 @@ module Protocol
 				
 				# A successful upgrade response implies that the connection will become a tunnel immediately after the empty line that concludes the header fields.
 				if headers[UPGRADE]
-					return read_tunnel_body
+					return read_upgrade_body
 				end
 				
 				# 6.  If this is a request message and none of the above are true, then

--- a/test/protocol/http1/connection.rb
+++ b/test/protocol/http1/connection.rb
@@ -205,8 +205,8 @@ describe Protocol::HTTP1::Connection do
 		with "GET" do
 			it "should ignore body for informational responses" do
 				body = client.read_response_body("GET", 100, {'content-length' => '10'})
-				expect(body).to be_a(::Protocol::HTTP1::Body::Remainder)
-				expect(client.persistent).to be == false
+				expect(body).to be_nil
+				expect(client.persistent).to be == true
 			end
 			
 			it "should ignore body for no content responses" do

--- a/test/protocol/http1/upgrade.rb
+++ b/test/protocol/http1/upgrade.rb
@@ -24,7 +24,7 @@ describe Protocol::HTTP1::Connection do
 			
 			expect(version).to be == request_version
 			expect(headers['upgrade']).to be == [protocol]
-			expect(body).to be_nil
+			expect(body).to be_a(Protocol::HTTP1::Body::Remainder)
 			
 			stream = server.hijack!
 			expect(stream.read).to be == "Hello World"


### PR DESCRIPTION
For the sake of implementing proxies, it might be nice to map upgrade requests/responses to appropriate bodies. Previously the only mechanism was to hijack the connection, but this makes implementing a generic proxy more complicated.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
