### PR TITLE
Relax header parsing to allow high bytes and most control characters.

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -37,10 +37,9 @@ module Protocol
 		
 		# HTTP/1.x header parser:
 		FIELD_NAME = TOKEN
-		WS = /[ \t]/ # Whitespace.
-		OWS = /#{WS}*/ # Optional whitespace.
-		VCHAR = /[!-~]/ # Match visible characters from ASCII 33 to 126.
-		FIELD_VALUE = /#{VCHAR}+(?:#{WS}+#{VCHAR}+)*/.freeze
+		OWS = /[ \t]*/
+		# A field value is any string of characters that does not contain a null character, CR, or LF. After reflecting on the RFCs and surveying real implementations, I came to the conclusion that the RFCs are too restrictive. Most servers only check for the presence of null bytes, and obviously CR/LF characters have semantic meaning in the parser. So, I decided to follow this defacto standard, even if I'm not entirely happy with it.
+		FIELD_VALUE = /[^\0\r\n]+/.freeze
 		HEADER = /\A(#{FIELD_NAME}):#{OWS}(?:(#{FIELD_VALUE})#{OWS})?\z/.freeze
 		
 		VALID_FIELD_NAME = /\A#{FIELD_NAME}\z/.freeze

--- a/test/protocol/http1/connection/headers.rb
+++ b/test/protocol/http1/connection/headers.rb
@@ -59,6 +59,20 @@ describe Protocol::HTTP1::Connection do
 			"user-agent: Mozilla\x7FHacker Browser"
 		]}
 
+		it "allows the request" do
+			authority, method, target, version, headers, body = server.read_request
+
+			expect(headers).to have_keys(
+				"user-agent" => be == "Mozilla\x7FHacker Browser"
+			)
+		end
+	end
+
+	with "header that contains null character" do
+		let(:headers) {[
+			"user-agent: Mozilla\x00Hacker Browser"
+		]}
+
 		it "rejects the request" do
 			expect do
 				server.read_request


### PR DESCRIPTION
We found header values in the wild containing high bytes. After [surveying the landscape](https://github.com/rack/rack/issues/2308), it seems like the RFC specification is unrealistic.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
