### PR TITLE
Ignore connection errors in `read_line?`.

### DIFF
--- a/lib/protocol/http1/connection.rb
+++ b/lib/protocol/http1/connection.rb
@@ -349,7 +349,7 @@ module Protocol
 			
 			# Read a line from the connection.
 			#
-			# @returns [String | Nil] the line read, or nil if the connection is gracefully closed.
+			# @returns [String | Nil] the line read, or nil if the connection is closed.
 			# @raises [LineLengthError] if the line is too long.
 			# @raises [ProtocolError] if the line is not terminated properly.
 			def read_line?
@@ -366,8 +366,9 @@ module Protocol
 				end
 				
 				return line
-				
-				# I considered rescuing Errno::ECONNRESET here, but it seems like that would be ignoring a potentially serious error.
+			# If a connection is shut down abruptly, we treat it as EOF, but only specifically in `read_line?`.
+			rescue Errno::ECONNRESET
+				return nil
 			end
 			
 			# Read a line from the connection.

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
   - Tidy up implementation of `read_line?` to handle line length errors and protocol violations more clearly.
+  - Improve error handling for unexpected connection closures (`Errno::ECONNRESET`) in `read_line?`.
 
 ## v0.35.0
 

--- a/test/protocol/http1/connection.rb
+++ b/test/protocol/http1/connection.rb
@@ -48,6 +48,12 @@ describe Protocol::HTTP1::Connection do
 				server.read_line?
 			end.to raise_exception(Protocol::HTTP1::ProtocolError)
 		end
+		
+		it "returns nil on Errno::ECONNRESET" do
+			expect(server.stream).to receive(:gets).and_raise(Errno::ECONNRESET)
+			
+			expect(server.read_line?).to be_nil
+		end
 	end
 	
 	with "#read_request" do


### PR DESCRIPTION
If the remote connection abruptly terminates the stream, return `nil` from `read_line?`.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
