### PR TITLE
Handle EOF while reading chunked trailers.

### DIFF
--- a/lib/protocol/http1/body/chunked.rb
+++ b/lib/protocol/http1/body/chunked.rb
@@ -128,7 +128,7 @@ module Protocol
 						connection.close_read
 					end
 					
-					raise EOFError, "Connection closed before expected length was read!"
+					raise
 				end
 				
 				# @returns [String] a human-readable representation of the body.
@@ -149,7 +149,7 @@ module Protocol
 				
 				# Read the trailer from the connection, and add any headers to the trailer.
 				def read_trailer
-					while line = @connection.read_line?
+					while line = @connection.read_line
 						# Empty line indicates end of trailer:
 						break if line.empty?
 						

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Handle unexpected EOF while reading chunked trailers.
+
 ## v0.40.1
 
   - Bound fixed-length and chunked body reads, and validate chunk terminators.

--- a/test/protocol/http1/body/chunked.rb
+++ b/test/protocol/http1/body/chunked.rb
@@ -128,6 +128,16 @@ describe Protocol::HTTP1::Body::Chunked do
 			end
 		end
 		
+		with "incomplete trailer" do
+			let(:buffer) {StringIO.new("0\r\n")}
+			
+			it "raises EOFError when the final CRLF is missing" do
+				expect{body.read}.to raise_exception(EOFError)
+				
+				expect(connection).to be(:half_closed_remote?)
+			end
+		end
+		
 		with "bad trailers" do
 			let(:postfix) {":ETag abcd\r\n"}
 			


### PR DESCRIPTION
## Summary

- require the final CRLF after the chunked trailer section
- preserve the original EOFError when cleaning up the connection
- add regression coverage for a truncated chunked body

RFC 9112 §7.1 defines the ending as `last-chunk trailer-section CRLF`.

## Testing

- `bundle exec sus test/protocol/http1/body/chunked.rb`
- `bundle exec sus`